### PR TITLE
Normalize image url and use promises instead of callbacks

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -58,16 +58,14 @@ client.login(config.token);
 
 // DB Test Case
 //
-// dbHandler.create(
-//   {
-//     link: 'http://www.youtube.com',
+// dbHandler
+//   .create({
+//     link: 'https://www.youtube.com/',
 //     author: {
 //       id: 'test',
 //       username: 'test',
 //       discriminator: 'test'
 //     }
-//   },
-//   payload => {
-//     console.log(payload);
-//   }
-// );
+//   })
+//   .then(response => console.log(response))
+//   .catch(error => console.log(error));

--- a/db/resource.db.js
+++ b/db/resource.db.js
@@ -3,7 +3,6 @@ const urlMetadata = require('url-metadata');
 const config = require('../config.json');
 const Resource = require('../models/resource.model');
 const validator = require('../validations/resource.vaidation');
-const ValidationError = require('../validations/ValidationError');
 const utils = require('../utils');
 
 mongoose.Promise = Promise;
@@ -14,40 +13,44 @@ mongoose.connect(
 
 const resourceHandler = {};
 
-resourceHandler.create = ({ link, author }, callback) => {
-  let payload = {
-    error: true,
-    message: ''
-  };
-  const validationResult = validator({ link, author });
-  if (validationResult instanceof ValidationError) {
-    payload.message = validationResult.message;
-    callback(payload);
-  } else {
-    urlMetadata(link).then(metadata => {
-      const meta = {
-        title: metadata.title,
-        image: utils.normalizeUrl(metadata.image, utils.getDomain(link)),
-        description: metadata.description
-      };
-      const resource = new Resource({
-        link,
-        meta,
-        author
+resourceHandler.create = ({ link, author }) => {
+  return new Promise((resolve, reject) => {
+    let payload = {
+      error: true,
+      message: ''
+    };
+    validator({ link, author })
+      .then(() => {
+        urlMetadata(link).then(metadata => {
+          const meta = {
+            title: metadata.title,
+            image: utils.normalizeUrl(metadata.image, utils.getDomain(link)),
+            description: metadata.description
+          };
+          const resource = new Resource({
+            link,
+            meta,
+            author
+          });
+          resource.save(error => {
+            if (error) {
+              payload.message =
+                'There is a problem adding into the database. Please try agian later';
+              reject(payload);
+            } else {
+              payload.error = false;
+              payload.message = 'Successfully added into the database';
+              resolve(payload);
+            }
+          });
+        });
+      })
+      .catch(error => {
+        console.log(error.message);
+        payload.message = error.message;
+        reject(payload);
       });
-      resource.save(error => {
-        if (error) {
-          payload.message =
-            'There is a problem adding into the database. Please try agian later';
-          callback(payload);
-        } else {
-          payload.error = false;
-          payload.message = 'Successfully added into the database';
-          callback(payload);
-        }
-      });
-    });
-  }
+  });
 };
 
 module.exports = resourceHandler;

--- a/db/resource.db.js
+++ b/db/resource.db.js
@@ -1,9 +1,10 @@
 const mongoose = require('mongoose');
+const urlMetadata = require('url-metadata');
 const config = require('../config.json');
 const Resource = require('../models/resource.model');
 const validator = require('../validations/resource.vaidation');
 const ValidationError = require('../validations/ValidationError');
-const urlMetadata = require('url-metadata');
+const utils = require('../utils');
 
 mongoose.Promise = Promise;
 mongoose.connect(
@@ -26,7 +27,7 @@ resourceHandler.create = ({ link, author }, callback) => {
     urlMetadata(link).then(metadata => {
       const meta = {
         title: metadata.title,
-        image: metadata.image,
+        image: utils.normalizeUrl(metadata.image, utils.getDomain(link)),
         description: metadata.description
       };
       const resource = new Resource({

--- a/utils/get-domain.js
+++ b/utils/get-domain.js
@@ -1,0 +1,5 @@
+module.exports = url =>
+  url
+    .split('/')
+    .splice(0, 3)
+    .join('/');

--- a/utils/index.js
+++ b/utils/index.js
@@ -1,0 +1,7 @@
+const getDomain = require('./get-domain');
+const normalizeUrl = require('./normalize-url');
+
+module.exports = {
+  getDomain,
+  normalizeUrl
+};

--- a/utils/normalize-url.js
+++ b/utils/normalize-url.js
@@ -1,0 +1,9 @@
+module.exports = (url, domain) => {
+  let normalizedUrl = '';
+  if (/^\//.test(url)) {
+    normalizedUrl = domain + url;
+  } else {
+    normalizedUrl = url;
+  }
+  return normalizedUrl;
+};

--- a/validations/resource.vaidation.js
+++ b/validations/resource.vaidation.js
@@ -1,34 +1,47 @@
+const urlMetadata = require('url-metadata');
 const ValidationError = require('./ValidationError');
 
 module.exports = payload => {
-  if (!payload.link) {
-    return new ValidationError('Link is required');
-  }
+  return new Promise((resolve, reject) => {
+    if (!payload.link) {
+      reject(new ValidationError('Link is required'));
+    }
 
-  const urlPattern = /^(?:(?:https?|ftp):\/\/)?(?:(?!(?:10|127)(?:\.\d{1,3}){3})(?!(?:169\.254|192\.168)(?:\.\d{1,3}){2})(?!172\.(?:1[6-9]|2\d|3[0-1])(?:\.\d{1,3}){2})(?:[1-9]\d?|1\d\d|2[01]\d|22[0-3])(?:\.(?:1?\d{1,2}|2[0-4]\d|25[0-5])){2}(?:\.(?:[1-9]\d?|1\d\d|2[0-4]\d|25[0-4]))|(?:(?:[a-z\u00a1-\uffff0-9]-*)*[a-z\u00a1-\uffff0-9]+)(?:\.(?:[a-z\u00a1-\uffff0-9]-*)*[a-z\u00a1-\uffff0-9]+)*(?:\.(?:[a-z\u00a1-\uffff]{2,})))(?::\d{2,5})?(?:\/\S*)?$/;
+    const urlPattern = /^(?:(?:https?|ftp):\/\/)?(?:(?!(?:10|127)(?:\.\d{1,3}){3})(?!(?:169\.254|192\.168)(?:\.\d{1,3}){2})(?!172\.(?:1[6-9]|2\d|3[0-1])(?:\.\d{1,3}){2})(?:[1-9]\d?|1\d\d|2[01]\d|22[0-3])(?:\.(?:1?\d{1,2}|2[0-4]\d|25[0-5])){2}(?:\.(?:[1-9]\d?|1\d\d|2[0-4]\d|25[0-4]))|(?:(?:[a-z\u00a1-\uffff0-9]-*)*[a-z\u00a1-\uffff0-9]+)(?:\.(?:[a-z\u00a1-\uffff0-9]-*)*[a-z\u00a1-\uffff0-9]+)*(?:\.(?:[a-z\u00a1-\uffff]{2,})))(?::\d{2,5})?(?:\/\S*)?$/;
 
-  if (!urlPattern.test(payload.link)) {
-    return new ValidationError('Please enter a valid URL');
-  }
+    if (!urlPattern.test(payload.link)) {
+      rejct(new ValidationError('Please enter a valid URL'));
+    }
 
-  if (!payload.author || typeof payload.author !== 'object') {
-    return new ValidationError('Please enter a valid author object');
-  }
+    if (!payload.author || typeof payload.author !== 'object') {
+      reject(new ValidationError('Please enter a valid author object'));
+    }
 
-  if (!payload.author.id || typeof payload.author.id !== 'string') {
-    return new ValidationError('Please enter a valid User ID');
-  }
+    if (!payload.author.id || typeof payload.author.id !== 'string') {
+      reject(new ValidationError('Please enter a valid User ID'));
+    }
 
-  if (!payload.author.username || typeof payload.author.username !== 'string') {
-    return new ValidationError('Please enter a valid Username');
-  }
+    if (
+      !payload.author.username ||
+      typeof payload.author.username !== 'string'
+    ) {
+      reject(new ValidationError('Please enter a valid Username'));
+    }
 
-  if (
-    !payload.author.discriminator ||
-    typeof payload.author.discriminator !== 'string'
-  ) {
-    return new ValidationError('Please enter a valid discriminator');
-  }
+    if (
+      !payload.author.discriminator ||
+      typeof payload.author.discriminator !== 'string'
+    ) {
+      reject(new ValidationError('Please enter a valid discriminator'));
+    }
 
-  return true;
+    urlMetadata(payload.link)
+      .then(() => {
+        resolve(true);
+      })
+      .catch(error => {
+        if ((error.Error = 'response code 404'))
+          reject(new ValidationError('The provided URL does not exist'));
+      });
+  });
 };

--- a/validations/resource.vaidation.js
+++ b/validations/resource.vaidation.js
@@ -10,7 +10,7 @@ module.exports = payload => {
     const urlPattern = /^(?:(?:https?|ftp):\/\/)?(?:(?!(?:10|127)(?:\.\d{1,3}){3})(?!(?:169\.254|192\.168)(?:\.\d{1,3}){2})(?!172\.(?:1[6-9]|2\d|3[0-1])(?:\.\d{1,3}){2})(?:[1-9]\d?|1\d\d|2[01]\d|22[0-3])(?:\.(?:1?\d{1,2}|2[0-4]\d|25[0-5])){2}(?:\.(?:[1-9]\d?|1\d\d|2[0-4]\d|25[0-4]))|(?:(?:[a-z\u00a1-\uffff0-9]-*)*[a-z\u00a1-\uffff0-9]+)(?:\.(?:[a-z\u00a1-\uffff0-9]-*)*[a-z\u00a1-\uffff0-9]+)*(?:\.(?:[a-z\u00a1-\uffff]{2,})))(?::\d{2,5})?(?:\/\S*)?$/;
 
     if (!urlPattern.test(payload.link)) {
-      rejct(new ValidationError('Please enter a valid URL'));
+      reject(new ValidationError('Please enter a valid URL'));
     }
 
     if (!payload.author || typeof payload.author !== 'object') {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/22068550/51585445-6581a600-1eff-11e9-99f5-2de44b4f9207.png)

1.  YouTube's Image URL in metadata has only the absolute path to the image instead of the full URL. I don't know how many other sites do the same, or probably no other site does. but if someone adds YouTube (not YouTube videos, just the homepage) in our resources, then the image won't work as expected. so yeah I just added a utility function to normalize the URL in such cases

2. Replaced callbacks with promises